### PR TITLE
Hide password in userdata parser

### DIFF
--- a/files/create-sftp-user
+++ b/files/create-sftp-user
@@ -29,7 +29,8 @@ function validateArg() {
     fi
 }
 
-log "Parsing user data: \"$1\""
+# Replace password in log output with asterisks
+log "Parsing user data: \"$(echo "$1" | cut -d: -f1,3- | sed -e '1,/:/{s/:/:******:/}')\""
 IFS=':' read -ra args <<< "$1"
 
 skipIndex=0


### PR DESCRIPTION
Replace password in log output with asterisks
Fixes #362

## Results:
Before: `[bash] Parsing user data: "user:abc!123:3000:4000:/user/home"` After: `[bash] Parsing user data: "user:******:3000:4000:/user/home"`